### PR TITLE
Only allow sharing free content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 1. Do not @channel in #general.
 1. Respect each other and the tools we use.
 1. Check the channel list before you decide to make a new channel. If a channel already exists that you want to create, just join it and start chatting!
+1. Don't upload copyrighted content, unless it is freely available from the publisher.
 1. If you have an issue, contact an admin. You can see the list of admins down below.
 
 SADevs Slack is dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any chat topic. Participants violating these rules will be expelled from the group at the sole discretion of the group administrators.


### PR DESCRIPTION
Sharing copyrighted work that is not released under free licenses is a slippery slope that could get the group in trouble.  It would be best if we only share free work, e.g. Creative Commons and free samples and such.