### PR TITLE
fix: update join link

### DIFF
--- a/join_link.md
+++ b/join_link.md
@@ -2,4 +2,4 @@
 
 Share this link with people who are either in San Antonio, from San Antonio, work for a company in San Antonio, or are coming to move to San Antonio and are also developers of some kind.
 
-[Join the San Antonio Developer Slack Group here!](https://join.slack.com/t/sanantoniodevs/shared_invite/MjE2ODI0NDQ4NjkwLTE1MDA5MDgwODctMzcxMmZhNjE0Zg)
+[Join the San Antonio Developer Slack Group here!](https://join.slack.com/t/sanantoniodevs/shared_invite/zt-gsbtwgcj-nFjfegCQjx1RH2p3ll7tbQ)


### PR DESCRIPTION
https://sanantoniodevs.slack.com/archives/C012A1NKWDB/p1598015667000600
Shane let us know the link was expired. Looks like slack links expire every 30 days now.

We'll need to think on some automation to fix this. In the meantime I setup a slack reminder to update this every 25 days